### PR TITLE
Fixes docker run command volumes-from parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ This will create a stopped container wwith the name of `salt-master-data` and
 will hold our persistant salt master data. Now we just need to run our master
 container with the `--volumes-from` command:
 
-    docker run --rm -it --volume-from salt-master-data soon/salt-master
+    docker run --rm -it --volumes-from salt-master-data soon/salt-master
 
 ### Sharing Local Folders
 


### PR DESCRIPTION
Not sure if an older version of docker had a --volume-from or if this is just a typo. On 1.10.3 it's '--volumes-from'.
